### PR TITLE
Skip slides marked with `visibility` as false

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ yarn-error.log
 /libpeerconnection.log
 testem.log
 /typings
+.gitpod*
 
 # System files
 .DS_Store

--- a/public/assets/talks/a-look-inside-observables/structure.json
+++ b/public/assets/talks/a-look-inside-observables/structure.json
@@ -59,7 +59,8 @@
     "type": "image-only",
     "background": "transparent",
     "image": "./assets/images/sponsors--2024-beer-city-code.png",
-    "notes": "Sponsors"
+    "notes": "Sponsors",
+    "visibility": false
   },
   "what-is-rxjs--slide": {
     "title": "What is RxJS",

--- a/src/app/core/interfaces/structure.ts
+++ b/src/app/core/interfaces/structure.ts
@@ -10,6 +10,7 @@ export type StructureType = {
   author?: string;
   bio1?: string;
   bio2?: string;
+  visibility?: boolean;
 
   html?: string;
   panel?: string;

--- a/src/app/core/services/code.service.ts
+++ b/src/app/core/services/code.service.ts
@@ -31,28 +31,18 @@ export class CodeService {
 
   getStructure = async (folder: string): Promise<any> => {
     const structure: Structure = (await firstValueFrom(this.http.get(`./assets/talks/${ folder }/structure.json`)) as Structure);
-    
-    //Create a copy structure that will be finally passed
     var tempstruct: Structure ={ ORDER: [], STYLE: [] };
-
-    //Traverse through the object
     for(let i in structure){  
-
-      //Fetch the value variable (Either array or object) and traverse
       let j:any = structure[i];
-
-      //Check for visibility
       if (j['visibility'] == false){
         try{
-          //If visibility is false, remove from the ORDER array and don't add in tempstruct 
           tempstruct['ORDER'] = tempstruct['ORDER'].filter(item => item !== i);
         }
         catch(p){
-          console.error("Error in code service file", p); //Unlikely to ever occur
+          console.error("Error in code service file", p);
         }
       }
       else{
-        //If visibility is true or undefined, add the key and value to tempstruct
         tempstruct[i] = j;
       }
     }

--- a/src/app/core/services/code.service.ts
+++ b/src/app/core/services/code.service.ts
@@ -3,7 +3,7 @@ import { Injectable } from '@angular/core';
 import { BehaviorSubject, firstValueFrom } from 'rxjs';
 
 import { LoadedScript, WebComponent } from '../interfaces/web-components';
-import { Structure } from '../interfaces/structure';
+import { Structure, StructureType } from '../interfaces/structure';
 import { Talks } from '../interfaces/talks';
 
 @Injectable({
@@ -31,22 +31,17 @@ export class CodeService {
 
   getStructure = async (folder: string): Promise<any> => {
     const structure: Structure = (await firstValueFrom(this.http.get(`./assets/talks/${ folder }/structure.json`)) as Structure);
-    var tempstruct: Structure ={ ORDER: [], STYLE: [] };
-    for(let i in structure){  
-      let j:any = structure[i];
-      if (j['visibility'] == false){
-        try{
-          tempstruct['ORDER'] = tempstruct['ORDER'].filter(item => item !== i);
-        }
-        catch(p){
-          console.error("Error in code service file", p);
-        }
+    const tempStructure: Structure = { ORDER: [], STYLE: structure.STYLE };
+
+    structure.ORDER.forEach((key: string) => {
+      const objValue: StructureType = (structure[key] as StructureType);
+      if (objValue.hasOwnProperty('visibility') === false || objValue.visibility === true) {
+        tempStructure.ORDER.push(key);
+        tempStructure[key] = structure[key];
       }
-      else{
-        tempstruct[i] = j;
-      }
-    }
-    this.structure.next(tempstruct);
+    });
+    
+    this.structure.next(tempStructure);
   };
 
   getStructureImmediate = async (folder: string): Promise<Structure> => {

--- a/src/app/pages/talk/talk.component.ts
+++ b/src/app/pages/talk/talk.component.ts
@@ -38,9 +38,10 @@ export class TalkComponent implements OnDestroy {
 
   path: string = '';
   slideKey: string = '';
-  page: StructureType = { title: '', type: '' };
+  page: StructureType = { title: '', type: '', visibility: true };
   title: string = '';
   type: string = '';
+  visibility: boolean = true;
 
   fontsizeSelected: string | undefined;
 
@@ -153,7 +154,8 @@ export class TalkComponent implements OnDestroy {
     this.type = page.type;
     this.page = page;
     this.slideKey = key;
-
+    this.visibility = page.visibility ?? true; 
+    
     const style = structure.STYLE;
     this.style.add(style.join('\n'));
 

--- a/src/app/pages/talk/talk.component.ts
+++ b/src/app/pages/talk/talk.component.ts
@@ -199,7 +199,17 @@ export class TalkComponent implements OnDestroy {
 
     this.slideIndex++;
     const page: string = this.structure.ORDER[this.slideIndex];
-    this.setPage(page, this.structure);
+
+    //Check for visibility of slide
+    const currpage: StructureType = (this.structure[page] as StructureType);
+    currpage['visibility'] = currpage['visibility'] ?? true; 
+
+    if (currpage['visibility']== false){
+      this.next(); //Skip this page and display the next page if visibility is false
+    }
+    else{
+    this.setPage(page, this.structure); // Show the requested page
+    }
   };
 
   previous = (): void => {
@@ -213,10 +223,10 @@ export class TalkComponent implements OnDestroy {
     currpage['visibility'] = currpage['visibility'] ?? true; 
 
     if (currpage['visibility']== false){
-      this.previous();
+      this.previous(); //Skip this page and display the previous page if visibility is false
     }
     else{
-    this.setPage(page, this.structure);
+    this.setPage(page, this.structure); // Show the requested page
     }
   };
 

--- a/src/app/pages/talk/talk.component.ts
+++ b/src/app/pages/talk/talk.component.ts
@@ -41,7 +41,6 @@ export class TalkComponent implements OnDestroy {
   page: StructureType = { title: '', type: '', visibility: true };
   title: string = '';
   type: string = '';
-  visibility: boolean = true;
 
   fontsizeSelected: string | undefined;
 
@@ -154,7 +153,6 @@ export class TalkComponent implements OnDestroy {
     this.type = page.type;
     this.page = page;
     this.slideKey = key;
-    this.visibility = page.visibility ?? true; 
     
     const style = structure.STYLE;
     this.style.add(style.join('\n'));
@@ -209,7 +207,17 @@ export class TalkComponent implements OnDestroy {
     
     this.slideIndex--;
     const page: string = this.structure.ORDER[this.slideIndex];
+
+    //Check for visibility of slide
+    const currpage: StructureType = (this.structure[page] as StructureType);
+    currpage['visibility'] = currpage['visibility'] ?? true; 
+
+    if (currpage['visibility']== false){
+      this.previous();
+    }
+    else{
     this.setPage(page, this.structure);
+    }
   };
 
   end = (): void => {

--- a/src/app/pages/talk/talk.component.ts
+++ b/src/app/pages/talk/talk.component.ts
@@ -153,7 +153,7 @@ export class TalkComponent implements OnDestroy {
     this.type = page.type;
     this.page = page;
     this.slideKey = key;
-    
+
     const style = structure.STYLE;
     this.style.add(style.join('\n'));
 


### PR DESCRIPTION
Fixes #1 


#### Changelog
In this PR, I have made the following changes

- Add gitpod files in `.gitignore`. (I didn't want to run this project on my local machine)
- Marked a JSON entry for [this file](https://github.com/adityaraute/talk--presentation-tool/blob/b6a9e19163639c2bb32cd0ca998837583fee6c2a/public/assets/talks/a-look-inside-observables/structure.json#L63) with `visibility: false` for testing purposes.
- Include a `visibility` variable in `structure.ts` file
- In `Talkcomponent.ts` file, changed the page structure that is imported to included the `visibility` variable.
- In the same file, edited `previous()` and `next()` functions to skip any slides marked with `visibility: false` 

#### Limitations

- Unsure about how this will behave if the first or last page of the slideshow is marked with `visibility: false`. I assumed this won't realistically happen, so didn't bother to work on it at this stage.
- Did not change the serial numbers displayed in the bottom right, or the slide count displayed on the home screen.
- Have not written any unit tests for this feature.

I wanted to first get a sanity check about whether this is what you intended to do with the feature in the first place.
To test manually, try the **A Look Inside Observables** presentation, as linked above.